### PR TITLE
Feat/28

### DIFF
--- a/domain-common/src/main/java/org/example/model/council/CouncilDepartment.java
+++ b/domain-common/src/main/java/org/example/model/council/CouncilDepartment.java
@@ -1,6 +1,10 @@
 package org.example.model.council;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * 학생회 내의 부서를 나타내는 엔티티.
@@ -9,6 +13,10 @@ import jakarta.persistence.*;
  * 계층 구조(상위/하위 부서) 및 순서를 지정할 수 있다.
  */
 @Entity
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CouncilDepartment {
 
     // 부서 고유 ID
@@ -30,4 +38,5 @@ public class CouncilDepartment {
 
     // 부서 활성 여부 (soft delete 또는 임시 비활성 처리 용도)
     private Boolean isActive = true;
+
 }

--- a/domain-common/src/main/java/org/example/model/council/CouncilDepartmentRole.java
+++ b/domain-common/src/main/java/org/example/model/council/CouncilDepartmentRole.java
@@ -1,8 +1,16 @@
 package org.example.model.council;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
+
+//ENUM 으로 안할거임 -> 추후 국장 / 부장 자기가 원하는 name으로 설정할 수 있게 해야될듯.
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CouncilDepartmentRole {
 
     @Id
@@ -13,7 +21,7 @@ public class CouncilDepartmentRole {
     private CouncilDepartment department;
 
     @Column(nullable = false)
-    private String name; // 예: 국장, 부원, 실무자
+    private String name; // 예: Default 값 "회장","부회장","부장","부원"
 
     private Integer level; // 역할 순위 , 0 -> 국장, 1-> 부원
 }

--- a/domain-common/src/main/java/org/example/model/council/CouncilRolePermission.java
+++ b/domain-common/src/main/java/org/example/model/council/CouncilRolePermission.java
@@ -4,14 +4,16 @@ import jakarta.persistence.*;
 import org.example.model.enums.CouncilPermissionType;
 
 @Entity
-public class CouncilMemberPermission {
+@Table(name = "council_role_permission")
+public class CouncilRolePermission {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private CouncilMember member;
+    @JoinColumn(name = "department_role_id")
+    private CouncilDepartmentRole role;
 
     @Enumerated(EnumType.STRING)
     private CouncilPermissionType permission;

--- a/domain-common/src/main/java/org/example/model/enums/CouncilPermissionType.java
+++ b/domain-common/src/main/java/org/example/model/enums/CouncilPermissionType.java
@@ -6,36 +6,39 @@ package org.example.model.enums;
  */
 public enum CouncilPermissionType {
 
-    // 학생회 관리자 페이지 접근 권한
+    // 1. 학생회 관리자 페이지 접속
     ACCESS_ADMIN_PAGE("학생회 관리자 페이지 접속"),
 
-    // 구성원 권한 부여 (예: 부서장, 일반 구성원 등)
+    // 2. 권한 부여 가능 여부 (구성원 에게 역할 및 권한 설정 가능)
     GRANT_ROLE("구성원 권한 부여"),
 
-    // 구성원 목록 조회
+    // 3. 구성원 목록 열람
     VIEW_MEMBERS("구성원 열람"),
 
-    // 구성원 제명 처리
+    // 4. 구성원 제명
     REMOVE_MEMBER("구성원 제명"),
 
-    // 부서 생성 및 부서명 수정
+    // 5. 부서 생성 및 부서명 변경
     MANAGE_DEPARTMENT("부서 생성 및 부서명 변경"),
 
-    // 부서에 인원 배치
+    // 6. 부서 배정 (인원 배치)
     ASSIGN_TO_DEPARTMENT("부서 배정"),
 
-    // 초대 코드 생성 (학생회 or 일반)
-    GENERATE_INVITATION_CODE("초대코드 생성"),
+    // 7. 초대 코드 생성
+    GENERATE_INVITATION_CODE("초대 코드 생성"),
 
-    // 소속 인증 요청 승인/반려
-    PROCESS_AFFILIATION_VERIFICATION("소속인증 처리"),
+    // 8. 소속 인증 요청 승인/반려
+    PROCESS_AFFILIATION_VERIFICATION("소속 인증 처리"),
 
-    // 공지사항 작성, 수정, 삭제 등
-    MANAGE_NOTICE("공지 관리");
+    // 9. 공지 사항 작성/수정/삭제
+    MANAGE_NOTICE("공지사항 관리"),
+
+    // 10. 학생 개인 정보 (전화 번호와 학번 까지 _ 마스킹 없이 볼수 있게. )
+    VIEW_STUDENT_PRIVATE_INFO("학생 개인 정보 조회");
 
     private final String description;
 
-    CouncilPermissionType (String description) {
+    CouncilPermissionType(String description) {
         this.description = description;
     }
 

--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/CouncilCompositionController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/CouncilCompositionController.java
@@ -1,0 +1,18 @@
+package org.example.wecambackend.controller.admin;
+
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.wecambackend.config.security.annotation.IsCouncil;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@IsCouncil
+@RestController
+@RequestMapping("/admin/council/{councilName}/composition")
+@RequiredArgsConstructor
+@Tag(name = "Council Composition Controller", description = "학생회 관리자 페이지 내 구성원 관리 부분")
+public class CouncilCompositionController {
+
+
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilRolePermissionRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilRolePermissionRepository.java
@@ -1,9 +1,9 @@
 package org.example.wecambackend.repos;
 
-import org.example.model.council.CouncilMemberPermission;
+import org.example.model.council.CouncilRolePermission;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CouncilMemberPermissionRepository extends JpaRepository<CouncilMemberPermission, Long> {
+public interface CouncilRolePermissionRepository extends JpaRepository<CouncilRolePermission, Long> {
 }

--- a/wecam-backend/src/main/resources/db/migration/V20__createCouncilRolePermission.sql
+++ b/wecam-backend/src/main/resources/db/migration/V20__createCouncilRolePermission.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS council_member_permission;
+
+
+CREATE TABLE council_role_permission (
+                                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                         department_role_id BIGINT NOT NULL,
+                                         permission VARCHAR(50) NOT NULL,
+                                         CONSTRAINT fk_role_permission_department_role
+                                             FOREIGN KEY (department_role_id)
+                                                 REFERENCES council_department_role(id)
+                                                 ON DELETE CASCADE
+);


### PR DESCRIPTION
Entity 전폭 수정 

CouncilDepartment (학생회 부서)
필드명 | 설명
-- | --
id | 부서 ID (PK)
council | 소속 학생회
name | 부서명 (예: 기획국, 홍보국 등)
parentId | 상위 부서 ID (null이면 최상위)
isActive | 활성 상태 (soft delete 또는 비활성 처리용)

<!-- notionvc: f84dde35-6ec4-4659-9850-6e2f2c5a329a -->

 CouncilDepartmentRole (부서 내 역할)
필드명 | 설명
-- | --
id | 역할 ID (PK)
department | 소속 부서
name | 역할명 (예: 국장, 부원, 실무자)
level | 역할 우선순위 (숫자가 낮을수록 높은 직책)


<!-- notionvc: f84dde35-6ec4-4659-9850-6e2f2c5a329a -->

CouncilMember (학생회 구성원)
필드명 | 설명
-- | --
id | 구성원 ID (PK)
council | 소속 학생회
user | 사용자 정보 (User 참조)
department | 소속 부서
departmentRole | 부서 내 역할
memberRole | 학생회 내 주요 직책 (enum)
isActive | 재직 중 여부 (퇴출, 탈퇴 구분용)
<!-- notionvc: dee8d459-d293-4acf-b2ce-ca670cd9ef89 -->

CouncilRolePermission (역할 기반 권한)
필드명 | 설명
-- | --
id | 권한 ID (PK)
role | 부서 내 역할 (CouncilDepartmentRole)
permission | 권한 타입 (Enum: CouncilPermissionType)
<!-- notionvc: aae8d4fb-f1db-44d3-b772-b28395ed8ce2 -->

adminOrganzationService 에 Default 회장단 부서 생성 
