### PR TITLE
Feat/40

### DIFF
--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
@@ -5,13 +5,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.wecambackend.common.context.CouncilContextHolder;
 import org.example.wecambackend.common.response.BaseResponse;
 import org.example.wecambackend.common.response.BaseResponseStatus;
 import org.example.wecambackend.config.security.UserDetailsImpl;
-import org.example.wecambackend.config.security.annotation.CheckCouncilAccess;
 import org.example.wecambackend.config.security.annotation.IsCouncil;
 import org.example.wecambackend.config.security.annotation.IsPresidentTeam;
 import org.example.wecambackend.dto.requestDTO.StudentExpulsionRequest;
+import org.example.wecambackend.dto.responseDTO.UserSummaryResponse;
 import org.example.wecambackend.service.admin.StudentService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -52,20 +53,31 @@ public class StudentController {
 
     //학생회가 맡은 조직이 학과일 시, 해당 학과에 속한 일반 학생들 불러오기
     @IsCouncil
+    @GetMapping("/students")
     @Operation(
             summary = "해당 학생회가 관리하는 학생 유저 list 불러오기",
-            description = "접속한 X-council-Id 의 학생회가 관리하는 학생유저 list 반환 , 검색 태그 설정할 시 해당 태그에 속한 학생들을 반환함.",
+            description = "접속한 X-council-Id 의 학생회가 관리하는 학생유저 list 반환, 검색 태그 설정할 시 해당 태그에 속한 학생들을 반환함.",
             parameters = {
                     @Parameter(name = "X-Council-Id", description = "현재 접속 중인 학생회 ID (헤더)", in = ParameterIn.HEADER)
-            })
-    @GetMapping("/students/{studentNumber}/{grade}")
-    public BaseResponse<?> ShowOrganizationStudents(
+            }
+    )
+    public BaseResponse<List<UserSummaryResponse>> ShowOrganizationStudents(
+            @RequestParam(required = false)
+            @Parameter(description = "입학년도 뒷자리 (예: 21, 22). 다중 선택 가능", example = "21")
+            List<String> studentNumber,
+
+            @RequestParam(required = false)
+            @Parameter(description = "학년 (1~4). 다중 선택 가능", example = "1")
+            List<Integer> grade,
             @PathVariable("councilName") String councilName,
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable("studentNumber") List<String> studentNumber,
-            @PathVariable("grade") List<Integer> grade
-            ){
-        return new BaseResponse<>();
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        Long councilId = CouncilContextHolder.getCouncilId();
+        List<UserSummaryResponse> response = studentExpulsionService.showStudentListByDepartmentId(
+                councilId, studentNumber, grade
+        );
+        return new BaseResponse<>(response);
     }
+
 
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
@@ -9,6 +9,7 @@ import org.example.wecambackend.common.response.BaseResponse;
 import org.example.wecambackend.common.response.BaseResponseStatus;
 import org.example.wecambackend.config.security.UserDetailsImpl;
 import org.example.wecambackend.config.security.annotation.CheckCouncilAccess;
+import org.example.wecambackend.config.security.annotation.IsCouncil;
 import org.example.wecambackend.config.security.annotation.IsPresidentTeam;
 import org.example.wecambackend.dto.requestDTO.StudentExpulsionRequest;
 import org.example.wecambackend.service.admin.StudentService;
@@ -16,6 +17,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin/council/{councilName}/student")
@@ -26,7 +29,7 @@ public class StudentController {
     private final StudentService studentExpulsionService;
 
     @DeleteMapping("/{userId}")
-    @CheckCouncilAccess
+    @IsCouncil
     @IsPresidentTeam
     @Operation(
             summary = "일반 학생 제명",
@@ -46,4 +49,23 @@ public class StudentController {
         studentExpulsionService.expelStudent(userId, request.getReason());
         return new BaseResponse<>(BaseResponseStatus.SUCCESS, "학생이 성공적으로 제명되었습니다.");
     }
+
+    //학생회가 맡은 조직이 학과일 시, 해당 학과에 속한 일반 학생들 불러오기
+    @IsCouncil
+    @Operation(
+            summary = "해당 학생회가 관리하는 학생 유저 list 불러오기",
+            description = "접속한 X-council-Id 의 학생회가 관리하는 학생유저 list 반환 , 검색 태그 설정할 시 해당 태그에 속한 학생들을 반환함.",
+            parameters = {
+                    @Parameter(name = "X-Council-Id", description = "현재 접속 중인 학생회 ID (헤더)", in = ParameterIn.HEADER)
+            })
+    @GetMapping("/students/{studentNumber}/{grade}")
+    public BaseResponse<?> ShowOrganizationStudents(
+            @PathVariable("councilName") String councilName,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("studentNumber") List<String> studentNumber,
+            @PathVariable("grade") List<Integer> grade
+            ){
+        return new BaseResponse<>();
+    }
+
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
@@ -46,4 +46,4 @@ public class StudentController {
         studentExpulsionService.expelStudent(userId, request.getReason());
         return new BaseResponse<>(BaseResponseStatus.SUCCESS, "학생이 성공적으로 제명되었습니다.");
     }
-} 
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/projection/OrganizationNameLevelDto.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/projection/OrganizationNameLevelDto.java
@@ -1,0 +1,3 @@
+package org.example.wecambackend.dto.projection;
+
+public record OrganizationNameLevelDto(String organizationName, Integer level) {}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/UserSummaryResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/UserSummaryResponse.java
@@ -1,0 +1,18 @@
+package org.example.wecambackend.dto.responseDTO;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.example.model.enums.AcademicStatus;
+import org.example.model.enums.UserRole;
+
+@Getter @Setter
+@Builder
+public class UserSummaryResponse {
+    private Long userPkId; // 조회 , 제명 , 상세보기 등등 해야됨.
+    private String userName; // 학생 이름
+    private String studentNumber; // 2자리만..(맨 앞자리 4개에서 그 4자리 중 뒤에 2개..)
+    private String departmentName; //학과 이름
+    private Integer grade; // 학년 , 1자리임.
+    private AcademicStatus academicStatus; // 재학 , 휴학 여부
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilRepository.java
@@ -1,49 +1,59 @@
 package org.example.wecambackend.repos;
 
 import org.example.model.council.Council;
+import org.example.wecambackend.dto.projection.OrganizationNameLevelDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface CouncilRepository extends JpaRepository<Council,Long> {
      Boolean existsCouncilByOrganization_OrganizationId(Long orgId);
-     
+
      /**
       * 학생회를 조직 정보와 함께 조회
+      *
       * @param councilId 학생회 ID
       * @return 조직 정보가 포함된 학생회 정보
       */
      @Query("SELECT c FROM Council c LEFT JOIN FETCH c.organization WHERE c.id = :councilId")
      Optional<Council> findByIdWithOrganization(@Param("councilId") Long councilId);
-     
+
      /**
       * 하위 학생회 목록 조회 (단과대/총학생회 전용)
-      * 
+      * <p>
       * 계층 구조에 따라 모든 하위 학생회를 조회합니다:
       * - UNIVERSITY(level 0): COLLEGE, DEPARTMENT 학생회 모두 조회
       * - COLLEGE(level 1): DEPARTMENT 학생회 조회
-      * 
+      * <p>
       * 쿼리 조건:
       * 1. o.level > :parentLevel: 상위 조직보다 낮은 레벨의 모든 조직
       * 2. 직접 하위: o.parent.organizationId = :parentOrganizationId
       * 3. 간접 하위: EXISTS 절을 통해 2단계 하위 조직까지 포함
-      * 
+      *
       * @param parentOrganizationId 상위 조직 ID (현재 접속한 학생회의 조직 ID)
-      * @param parentLevel 상위 조직 레벨 (현재 접속한 학생회의 조직 레벨)
+      * @param parentLevel          상위 조직 레벨 (현재 접속한 학생회의 조직 레벨)
       * @return 하위 학생회 목록 (조직 레벨 순으로 정렬)
       */
      @Query("SELECT c FROM Council c " +
-            "LEFT JOIN FETCH c.organization o " +
-            "LEFT JOIN FETCH c.user u " +
-            "LEFT JOIN FETCH u.userInformation ui " +
-            "WHERE o.level > :parentLevel " +
-            "AND (o.parent.organizationId = :parentOrganizationId " +
-            "OR EXISTS (SELECT 1 FROM Organization parent WHERE parent.organizationId = :parentOrganizationId " +
-            "AND o.parent.parent = parent)) " +
-            "ORDER BY o.level, o.organizationName")
-     List<Council> findSubCouncilsByParentOrganization(@Param("parentOrganizationId") Long parentOrganizationId, 
+             "LEFT JOIN FETCH c.organization o " +
+             "LEFT JOIN FETCH c.user u " +
+             "LEFT JOIN FETCH u.userInformation ui " +
+             "WHERE o.level > :parentLevel " +
+             "AND (o.parent.organizationId = :parentOrganizationId " +
+             "OR EXISTS (SELECT 1 FROM Organization parent WHERE parent.organizationId = :parentOrganizationId " +
+             "AND o.parent.parent = parent)) " +
+             "ORDER BY o.level, o.organizationName")
+     List<Council> findSubCouncilsByParentOrganization(@Param("parentOrganizationId") Long parentOrganizationId,
                                                        @Param("parentLevel") int parentLevel);
+
+
+     /*해당 학생회의 조직 이름 출력*/
+     @Query("SELECT new org.example.wecambackend.dto.projection.OrganizationNameLevelDto(o.organizationName, o.level) " +
+             "FROM Council c JOIN c.organization o WHERE c.id = :councilId")
+     Optional<OrganizationNameLevelDto> findOrganizationNameByCouncilId(@Param("councilId") Long councilId);
+
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserRepository.java
@@ -1,11 +1,13 @@
 package org.example.wecambackend.repos;
 
 import org.example.model.user.User;
+import org.example.wecambackend.dto.responseDTO.UserSummaryResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,4 +28,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     String findNameByUserPkId(@Param("userId") Long userId);
 
     Optional<User> findUserByUserPkId(Long userId);
+
+
+    @Query("""
+    SELECT new org.example.wecambackend.dto.responseDTO.UserSummaryResponse(
+        u.userPkId, u.name,SUBSTRING(u.enrollYear, 3, 2),u.organization.organizationName,ui.studentGrade,ui.academicStatus
+    ) FROM User u left JOIN UserInformation ui WHERE u.status = org.example.model.common.BaseEntity.Status.ACTIVE
+    """)
+    List<UserSummaryResponse> findByUserSummaryByOrgIdAndTagsAndIsActive(Long orgId);
+
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/service/admin/StudentService.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/service/admin/StudentService.java
@@ -5,6 +5,9 @@ import org.example.model.enums.UserRole;
 import org.example.model.user.User;
 import org.example.wecambackend.common.exceptions.BaseException;
 import org.example.wecambackend.common.response.BaseResponseStatus;
+import org.example.wecambackend.dto.projection.OrganizationNameLevelDto;
+import org.example.wecambackend.dto.responseDTO.UserSummaryResponse;
+import org.example.wecambackend.repos.CouncilRepository;
 import org.example.wecambackend.repos.UserInformationRepository;
 import org.example.wecambackend.repos.UserRepository;
 import org.example.wecambackend.service.admin.common.EntityFinderService;
@@ -12,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -58,4 +63,44 @@ public class StudentService {
                     userInformationRepository.save(userInfo);
                 });
     }
-} 
+
+
+    /*학생 조회 서비스 로직 -> 학생 정보 조회이니까 Repos 에서 DTO 매핑 바로 할거임.
+    학생 조회 시 학년 정보는 UserInfo 테이블에서 , 입학년도는 User 테이블의 EnrolledYear 값 뒤 2개
+    나중에 Ehcache 캐시에 넣을 것 감안하고, 필터 조회가 많은걸 감안해서
+    해당 (OrganizationId) 에 속한 StudentList 를 먼저 조회한 뒤,
+    조회한 값에서 태그별 조회를 하는 게 좋을 거 같음.
+    TODO : 추후 캐시레벨 저장하면 됨.
+    organizationId에 속한 모든 학생을 한 번에 조회 → 이후 서비스 or 캐시 레벨에서 stdNumber, grade, tag 등으로 필터링
+     */
+    @Transactional(readOnly = true)
+    public List<UserSummaryResponse> showStudentListByDepartmentId
+    (Long councilId, List<String> stdNumber , List<Integer> grade){
+        OrganizationNameLevelDto organizationNameLevelDto =
+                councilRepository.findOrganizationNameByCouncilId(councilId)
+                        .orElseThrow(()->new BaseException(BaseResponseStatus.ACCESS_DENIED));
+        if (!organizationNameLevelDto.level().equals(2)) {
+            throw  new BaseException(BaseResponseStatus.ACCESS_DENIED);
+            // 학부 만 하게끔 (TODO: 전공은 우선 어떻게 할 지 생각해봐야 될 듯)
+        }
+
+        // 2. 학생 리스트 조회 (전체)
+        List<UserSummaryResponse> allStudents = userRepository.findByUserSummaryByOrgIdAndTagsAndIsActive(councilId);
+
+        // 3. 필터링 (입학년도 뒷자리, 학년)
+        return allStudents.stream()
+                .filter(student -> {
+                    boolean matchStd = (stdNumber == null || stdNumber.isEmpty()) ||
+                            stdNumber.contains(student.getStudentNumber());
+
+                    boolean matchGrade = (grade == null || grade.isEmpty()) ||
+                            grade.contains(student.getGrade());
+
+                    return matchStd && matchGrade;
+                })
+                .collect(Collectors.toList());
+    }
+
+
+    private final CouncilRepository councilRepository;
+}


### PR DESCRIPTION
## 🔀 Pull Request 제목
[Sprint5 : 학생관리] 학생 리스트 조회 API 필터링 및 Swagger 문서화 개선
---

## ✅ 작업 개요
 #40 

학부 단위 조직에서 속한 일반 학생 목록을 조회하는 API 구현

studentNumber(입학년도 뒷자리)와 grade(학년) 조건으로 필터링 가능

추후 캐시 적용을 고려해 전체 조회 후 메모리 내 필터 방식으로 설계

Swagger 상에서 파라미터 설명 및 선택형 리스트 문서화 적용


<!---- Resolves: #(Isuue Number) -->

---

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔧 주요 변경 사항

## 🔄 변경 내역 - `/students` API

| 구분          | 변경 내용                                                                 |
| ------------- | -------------------------------------------------------------------------- |
| 기능 추가       | `/students` GET API로 학부 소속 학생 전체 조회 및 필터 조회 기능 추가                    |
| 필터 로직       | 학번(4자리 중 뒤 2자리), 학년 조건에 따라 `Stream` 기반 필터링 로직 처리                      |
| Swagger 문서화 | `@Parameter` 애너테이션을 활용하여 각 필터 파라미터에 대한 설명 및 예시 명시                   |
| 예외 처리       | 요청 조직의 레벨이 학부(2)가 아닌 경우 `ACCESS_DENIED` 예외 반환                            |

---

## 🧪 테스트 내용

---

## 🧾 예외 응답 예시 (Swagger 문서화 연동)

```json
{
  "status": 401,
  "message": "로그인이 필요합니다.",
  "detail": "Unauthorized"
}
