### PR TITLE
Feat/issue 42

### DIFF
--- a/domain-common/build.gradle
+++ b/domain-common/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'org.example'
@@ -29,6 +30,32 @@ dependencies {
 
     // 스웨거
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+}
+
+// QueryDSL 설정
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
 
 test {

--- a/wecam-backend/build.gradle
+++ b/wecam-backend/build.gradle
@@ -78,8 +78,18 @@ dependencies {
 
     implementation project(':domain-common')
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 
 }
+
+// QueryDSL 설정 - domain-common의 Q클래스 사용
+sourceSets {
+    main.java.srcDir project(':domain-common').file('build/generated/sources/annotationProcessor/java/main')
+}
+
+// domain-common 컴파일 의존성 추가
+compileJava.dependsOn(':domain-common:compileJava')
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/wecam-backend/src/main/java/org/example/wecambackend/config/QuerydslConfig.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package org.example.wecambackend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/CouncilMemberController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/CouncilMemberController.java
@@ -10,6 +10,7 @@ import org.example.wecambackend.common.context.CouncilContextHolder;
 import org.example.wecambackend.config.security.UserDetailsImpl;
 import org.example.wecambackend.config.security.annotation.IsCouncil;
 import org.example.wecambackend.dto.responseDTO.CouncilMemberResponse;
+import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
 import org.example.wecambackend.service.admin.CouncilMemberService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -113,5 +114,25 @@ public class CouncilMemberController {
         String reason = request != null ? request.getReason() : null;
         councilMemberService.expelMember(memberId, reason);
         return new BaseResponse<>(BaseResponseStatus.SUCCESS, "구성원이 성공적으로 제명되었습니다.");
+    }
+
+    @GetMapping("/search")
+    @IsCouncil
+    @Operation(
+            summary = "학생회 구성원 검색",
+            description = "이름을 사용하여 학생회 구성원을 검색합니다.",
+            parameters = {
+                    @Parameter(name = "councilName", description = "학생회 이름", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "name", description = "검색할 이름", in = ParameterIn.QUERY, required = true),
+                    @Parameter(name = "X-Council-Id", description = "현재 접속한 학생회 ID", in = ParameterIn.HEADER, required = true)
+            }
+    )
+    public BaseResponse<List<CouncilMemberSearchResponse>> searchCouncilMembers(
+            @RequestParam String name,
+            @PathVariable("councilName") String councilName,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        List<CouncilMemberSearchResponse> response = councilMemberService.searchCouncilMembers(name);
+        return new BaseResponse<>(response);
     }
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
@@ -12,7 +12,9 @@ import org.example.wecambackend.config.security.UserDetailsImpl;
 import org.example.wecambackend.config.security.annotation.IsCouncil;
 import org.example.wecambackend.config.security.annotation.IsPresidentTeam;
 import org.example.wecambackend.dto.requestDTO.StudentExpulsionRequest;
+import org.example.wecambackend.dto.requestDTO.StudentSearchRequest;
 import org.example.wecambackend.dto.responseDTO.UserSummaryResponse;
+import org.example.wecambackend.dto.responseDTO.StudentSearchResponse;
 import org.example.wecambackend.service.admin.StudentService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -79,5 +81,33 @@ public class StudentController {
         return new BaseResponse<>(response);
     }
 
+    @GetMapping("/search")
+    @IsCouncil
+    @Operation(
+            summary = "일반 학생 검색",
+            description = "이름, 입학년도, 학년 필터를 사용하여 일반 학생을 검색합니다.",
+            parameters = {
+                    @Parameter(name = "councilName", description = "학생회 이름", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "name", description = "검색할 이름", in = ParameterIn.QUERY, required = true),
+                    @Parameter(name = "year", description = "입학년도 필터 (2021, 2022, 2023, 2024, 2025, 다중 선택 가능)", in = ParameterIn.QUERY),
+                    @Parameter(name = "grade", description = "학년 필터 (1~4, 다중 선택 가능)", in = ParameterIn.QUERY),
+                    @Parameter(name = "X-Council-Id", description = "현재 접속한 학생회 ID", in = ParameterIn.HEADER, required = true)
+            }
+    )
+    public BaseResponse<List<StudentSearchResponse>> searchStudents(
+            @RequestParam String name,
+            @RequestParam(required = false) List<String> year,
+            @RequestParam(required = false) List<Integer> grade,
+            @PathVariable("councilName") String councilName,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        StudentSearchRequest request = new StudentSearchRequest();
+        request.setName(name);
+        request.setYear(year);
+        request.setGrade(grade);
+        
+        List<StudentSearchResponse> response = studentExpulsionService.searchStudents(request);
+        return new BaseResponse<>(response);
+    }
 
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/StudentController.java
@@ -89,8 +89,8 @@ public class StudentController {
             parameters = {
                     @Parameter(name = "councilName", description = "학생회 이름", in = ParameterIn.PATH, required = true),
                     @Parameter(name = "name", description = "검색할 이름", in = ParameterIn.QUERY, required = true),
-                    @Parameter(name = "year", description = "입학년도 필터 (2021, 2022, 2023, 2024, 2025, 다중 선택 가능)", in = ParameterIn.QUERY),
-                    @Parameter(name = "grade", description = "학년 필터 (1~4, 다중 선택 가능)", in = ParameterIn.QUERY),
+                    @Parameter(name = "year", description = "입학년도 필터 (2019 ~ 2025, 다중 선택 가능)", in = ParameterIn.QUERY),
+                    @Parameter(name = "grade", description = "학년 필터 (1 ~ 4, 다중 선택 가능)", in = ParameterIn.QUERY),
                     @Parameter(name = "X-Council-Id", description = "현재 접속한 학생회 ID", in = ParameterIn.HEADER, required = true)
             }
     )

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/auto/LoginRequest.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/auto/LoginRequest.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class LoginRequest {
 
-    @Schema(description = "이메일", example = "president@wecampus.kr", required = true)
+    @Schema(description = "이메일", example = "president@example.com", required = true)
     private String email;
 
     @Schema(description = "비밀번호", example = "1234", required = true)

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/requestDTO/CouncilMemberSearchRequest.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/requestDTO/CouncilMemberSearchRequest.java
@@ -1,0 +1,17 @@
+package org.example.wecambackend.dto.requestDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@Schema(description = "학생회 구성원 검색 요청 DTO")
+public class CouncilMemberSearchRequest {
+    
+    @Schema(description = "검색할 이름", example = "김철수", required = true)
+    @NotBlank(message = "검색할 이름을 입력해주세요.")
+    private String name;
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/requestDTO/StudentSearchRequest.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/requestDTO/StudentSearchRequest.java
@@ -1,0 +1,24 @@
+package org.example.wecambackend.dto.requestDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "일반 학생 검색 요청 DTO")
+public class StudentSearchRequest {
+    
+    @Schema(description = "검색할 이름", example = "김철수", required = true)
+    @NotBlank(message = "검색할 이름을 입력해주세요.")
+    private String name;
+    
+    @Schema(description = "입학년도 필터 (19~25, 다중 선택 가능, 생략 시 전체)", example = "[\"25\", \"24\"]")
+    private List<String> year;
+    
+    @Schema(description = "학년 필터 (1~4, 다중 선택 가능, 생략 시 전체)", example = "[1, 2]")
+    private List<Integer> grade;
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/CouncilMemberSearchResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/CouncilMemberSearchResponse.java
@@ -1,0 +1,37 @@
+package org.example.wecambackend.dto.responseDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Schema(description = "학생회 구성원 검색 결과 DTO")
+public class CouncilMemberSearchResponse {
+    
+    @Schema(description = "사용자 ID")
+    private Long userPkId;
+
+    @Schema(description = "학생회 구성원 ID")
+    private Long councilMemberPkId;
+    
+    @Schema(description = "사용자 이름")
+    private String name;
+    
+    @Schema(description = "학번 (입학년도 뒷자리)")
+    private String studentNumber;
+    
+    @Schema(description = "학부명")
+    private String organizationName;
+    
+    @Schema(description = "부서명")
+    private String departmentName;
+    
+    @Schema(description = "직책 (부장, 부원 등)")
+    private String position;
+    
+    @Schema(description = "사용자 프로필 사진 경로")
+    private String profileImagePath;
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/CouncilMemberSearchResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/CouncilMemberSearchResponse.java
@@ -1,13 +1,17 @@
 package org.example.wecambackend.dto.responseDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "학생회 구성원 검색 결과 DTO")
 public class CouncilMemberSearchResponse {
     

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/StudentSearchResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/StudentSearchResponse.java
@@ -1,0 +1,34 @@
+package org.example.wecambackend.dto.responseDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Schema(description = "일반 학생 검색 결과 DTO")
+public class StudentSearchResponse {
+    
+    @Schema(description = "사용자 ID")
+    private Long userPkId;
+    
+    @Schema(description = "사용자 이름")
+    private String name;
+    
+    @Schema(description = "학번 (입학년도 4자리)")
+    private String studentNumber;
+    
+    @Schema(description = "학부명")
+    private String organizationName;
+    
+    @Schema(description = "학년")
+    private Integer grade;
+    
+    @Schema(description = "재학/휴학 여부")
+    private String academicStatus;
+    
+    @Schema(description = "사용자 프로필 사진 경로")
+    private String profileImagePath;
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/StudentSearchResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/responseDTO/StudentSearchResponse.java
@@ -1,13 +1,17 @@
 package org.example.wecambackend.dto.responseDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "일반 학생 검색 결과 DTO")
 public class StudentSearchResponse {
     

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilMemberCustomRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilMemberCustomRepository.java
@@ -1,0 +1,17 @@
+package org.example.wecambackend.repos;
+
+import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
+
+import java.util.List;
+
+public interface CouncilMemberCustomRepository {
+    
+    /**
+     * 학생회 구성원 검색
+     * 
+     * @param name 검색할 이름
+     * @param councilId 현재 학생회 ID
+     * @return 학생회 구성원 검색 결과 목록
+     */
+    List<CouncilMemberSearchResponse> searchCouncilMembers(String name, Long councilId);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilMemberCustomRepositoryImpl.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilMemberCustomRepositoryImpl.java
@@ -1,0 +1,51 @@
+package org.example.wecambackend.repos;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.model.council.QCouncilMember;
+import org.example.model.organization.QOrganization;
+import org.example.model.user.QUser;
+import org.example.model.user.QUserInformation;
+import org.example.model.enums.UserRole;
+import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CouncilMemberCustomRepositoryImpl implements CouncilMemberCustomRepository {
+    
+    private final JPAQueryFactory queryFactory;
+    
+    private final QUser user = QUser.user;
+    private final QUserInformation userInfo = QUserInformation.userInformation;
+    private final QOrganization organization = QOrganization.organization;
+    private final QCouncilMember councilMember = QCouncilMember.councilMember;
+    
+    @Override
+    public List<CouncilMemberSearchResponse> searchCouncilMembers(String name, Long councilId) {
+        return queryFactory
+            .select(Projections.constructor(CouncilMemberSearchResponse.class,
+                user.userPkId,
+                councilMember.id,
+                user.name,
+                user.enrollYear,
+                organization.organizationName,
+                councilMember.department.name,
+                councilMember.memberRole.stringValue(),
+                userInfo.profileImagePath
+            ))
+            .from(user)
+            .leftJoin(organization).on(user.organizationId.eq(organization.organizationId))
+            .leftJoin(councilMember).on(user.userPkId.eq(councilMember.user.userPkId))
+            .where(
+                councilMember.council.id.eq(councilId),
+                user.name.contains(name),
+                user.role.eq(UserRole.COUNCIL),
+                user.status.eq(org.example.model.common.BaseEntity.Status.ACTIVE)
+            )
+            .fetch();
+    }
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilMemberRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/CouncilMemberRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 import org.example.model.council.CouncilDepartment;
 import org.example.model.enums.MemberRole;
 
-public interface CouncilMemberRepository extends JpaRepository<CouncilMember,Long> {
+public interface CouncilMemberRepository extends JpaRepository<CouncilMember,Long>, CouncilMemberCustomRepository {
 
 //    Boolean existsByUserUserPkIdAndCouncil_Organization_organizationIdAndStatus(Long userId, Long organizationId);
     @Query("select cm.council.id from CouncilMember cm where cm.user.userPkId = :userPkId and cm.status = org.example.model.common.BaseEntity.Status.ACTIVE")

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepository.java
@@ -1,0 +1,27 @@
+package org.example.wecambackend.repos;
+
+import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
+import org.example.wecambackend.dto.responseDTO.StudentSearchResponse;
+
+import java.util.List;
+
+public interface UserCustomRepository {
+    
+    /**
+     * 학생회 구성원 검색
+     * 
+     * @param name 검색할 이름
+     * @return 학생회 구성원 검색 결과 목록
+     */
+    List<CouncilMemberSearchResponse> searchCouncilMembers(String name);
+    
+    /**
+     * 일반 학생 검색
+     * 
+     * @param name 검색할 이름
+     * @param years 입학년도 필터 (null이면 전체)
+     * @param grades 학년 필터 (null이면 전체)
+     * @return 일반 학생 검색 결과 목록
+     */
+    List<StudentSearchResponse> searchStudents(String name, List<String> years, List<Integer> grades);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepository.java
@@ -1,20 +1,10 @@
 package org.example.wecambackend.repos;
 
-import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
 import org.example.wecambackend.dto.responseDTO.StudentSearchResponse;
 
 import java.util.List;
 
 public interface UserCustomRepository {
-    
-    /**
-     * 학생회 구성원 검색
-     * 
-     * @param name 검색할 이름
-     * @param councilId 현재 학생회 ID
-     * @return 학생회 구성원 검색 결과 목록
-     */
-    List<CouncilMemberSearchResponse> searchCouncilMembers(String name, Long councilId);
     
     /**
      * 일반 학생 검색

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepository.java
@@ -11,9 +11,10 @@ public interface UserCustomRepository {
      * 학생회 구성원 검색
      * 
      * @param name 검색할 이름
+     * @param councilId 현재 학생회 ID
      * @return 학생회 구성원 검색 결과 목록
      */
-    List<CouncilMemberSearchResponse> searchCouncilMembers(String name);
+    List<CouncilMemberSearchResponse> searchCouncilMembers(String name, Long councilId);
     
     /**
      * 일반 학생 검색

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepositoryImpl.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepositoryImpl.java
@@ -4,13 +4,11 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.example.model.council.QCouncilMember;
 import org.example.model.organization.QOrganization;
 import org.example.model.user.QUser;
 import org.example.model.user.QUserInformation;
 import org.example.model.user.QUserPrivate;
 import org.example.model.enums.UserRole;
-import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
 import org.example.wecambackend.dto.responseDTO.StudentSearchResponse;
 import org.springframework.stereotype.Repository;
 
@@ -25,32 +23,6 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
     private final QUser user = QUser.user;
     private final QUserInformation userInfo = QUserInformation.userInformation;
     private final QOrganization organization = QOrganization.organization;
-    private final QCouncilMember councilMember = QCouncilMember.councilMember;
-    
-    @Override
-    public List<CouncilMemberSearchResponse> searchCouncilMembers(String name, Long councilId) {
-        return queryFactory
-            .select(Projections.constructor(CouncilMemberSearchResponse.class,
-                user.userPkId,
-                councilMember.id,
-                user.name,
-                user.enrollYear,
-                organization.organizationName,
-                councilMember.department.name,
-                councilMember.memberRole.stringValue(),
-                userInfo.profileImagePath
-            ))
-            .from(user)
-            .leftJoin(organization).on(user.organizationId.eq(organization.organizationId))
-            .leftJoin(councilMember).on(user.userPkId.eq(councilMember.user.userPkId))
-            .where(
-                councilMember.council.id.eq(councilId),
-                user.name.contains(name),
-                user.role.eq(UserRole.COUNCIL),
-                user.status.eq(org.example.model.common.BaseEntity.Status.ACTIVE)
-            )
-            .fetch();
-    }
     
     @Override
     public List<StudentSearchResponse> searchStudents(String name, List<String> years, List<Integer> grades) {

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepositoryImpl.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserCustomRepositoryImpl.java
@@ -1,0 +1,90 @@
+package org.example.wecambackend.repos;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.model.council.QCouncilMember;
+import org.example.model.organization.QOrganization;
+import org.example.model.user.QUser;
+import org.example.model.user.QUserInformation;
+import org.example.model.user.QUserPrivate;
+import org.example.model.enums.UserRole;
+import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
+import org.example.wecambackend.dto.responseDTO.StudentSearchResponse;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+    
+    private final JPAQueryFactory queryFactory;
+    
+    private final QUser user = QUser.user;
+    private final QUserInformation userInfo = QUserInformation.userInformation;
+    private final QOrganization organization = QOrganization.organization;
+    private final QCouncilMember councilMember = QCouncilMember.councilMember;
+    
+    @Override
+    public List<CouncilMemberSearchResponse> searchCouncilMembers(String name) {
+        return queryFactory
+            .select(Projections.constructor(CouncilMemberSearchResponse.class,
+                user.userPkId,
+                councilMember.id,
+                user.name,
+                user.enrollYear,
+                organization.organizationName,
+                councilMember.department.name,
+                councilMember.memberRole.stringValue(),
+                userInfo.profileImagePath
+            ))
+            .from(user)
+            .leftJoin(organization).on(user.organizationId.eq(organization.organizationId))
+            .leftJoin(councilMember).on(user.userPkId.eq(councilMember.user.userPkId))
+            .where(
+                user.name.contains(name),
+                user.role.eq(UserRole.COUNCIL),
+                user.status.eq(org.example.model.common.BaseEntity.Status.ACTIVE)
+            )
+            .fetch();
+    }
+    
+    @Override
+    public List<StudentSearchResponse> searchStudents(String name, List<String> years, List<Integer> grades) {
+        BooleanBuilder builder = new BooleanBuilder();
+        
+        // 기본 조건: 이름 검색 + UNAUTH, ADMIN이 아닌 사용자 + 활성 상태
+        builder.and(user.name.contains(name));
+        builder.and(user.role.ne(UserRole.ADMIN));
+        builder.and(user.role.ne(UserRole.UNAUTH));
+        builder.and(user.status.eq(org.example.model.common.BaseEntity.Status.ACTIVE));
+        
+        // 입학년도 필터
+        if (years != null && !years.isEmpty()) {
+            builder.and(user.enrollYear.in(years));
+        }
+        
+        // 학년 필터
+        if (grades != null && !grades.isEmpty()) {
+            builder.and(userInfo.studentGrade.in(grades));
+        }
+        
+        return queryFactory
+            .select(Projections.constructor(StudentSearchResponse.class,
+                user.userPkId,
+                user.name,
+                user.enrollYear,
+                organization.organizationName,
+                userInfo.studentGrade,
+                userInfo.academicStatus.stringValue().coalesce("정보 없음"), // 재학 정보 없으면 "정보 없음" 반환
+                userInfo.profileImagePath
+            ))
+            .from(user)
+            .leftJoin(userInfo).on(user.userPkId.eq(userInfo.user.userPkId))
+            .leftJoin(organization).on(user.organizationId.eq(organization.organizationId))
+            .where(builder)
+            .fetch();
+    }
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
     Optional<User> findByEmail(String email);
 
     @Query("SELECT u FROM User u JOIN FETCH u.userPrivate WHERE u.email = :email")

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/UserRepositoryCustom.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/UserRepositoryCustom.java
@@ -1,0 +1,27 @@
+package org.example.wecambackend.repos;
+
+import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
+import org.example.wecambackend.dto.responseDTO.StudentSearchResponse;
+
+import java.util.List;
+
+public interface UserRepositoryCustom {
+    
+    /**
+     * 학생회 구성원 검색
+     * 
+     * @param name 검색할 이름
+     * @return 학생회 구성원 검색 결과 목록
+     */
+    List<CouncilMemberSearchResponse> searchCouncilMembers(String name);
+    
+    /**
+     * 일반 학생 검색
+     * 
+     * @param name 검색할 이름
+     * @param years 입학년도 필터 (null이면 전체)
+     * @param grades 학년 필터 (null이면 전체)
+     * @return 일반 학생 검색 결과 목록
+     */
+    List<StudentSearchResponse> searchStudents(String name, List<String> years, List<Integer> grades);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/service/admin/CouncilMemberService.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/service/admin/CouncilMemberService.java
@@ -178,6 +178,6 @@ public class CouncilMemberService {
     @Transactional(readOnly = true)
     public List<CouncilMemberSearchResponse> searchCouncilMembers(String name) {
         Long councilId = CouncilContextHolder.getCouncilId();
-        return userRepository.searchCouncilMembers(name, councilId);
+        return councilMemberRepository.searchCouncilMembers(name, councilId);
     }
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/service/admin/CouncilMemberService.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/service/admin/CouncilMemberService.java
@@ -14,6 +14,7 @@ import org.example.wecambackend.common.response.BaseResponseStatus;
 import org.example.wecambackend.dto.requestDTO.DepartmentAssignmentRequest;
 import org.example.wecambackend.dto.responseDTO.CouncilCompositionResponse;
 import org.example.wecambackend.dto.responseDTO.CouncilMemberResponse;
+import org.example.wecambackend.dto.responseDTO.CouncilMemberSearchResponse;
 import org.example.wecambackend.repos.CouncilMemberRepository;
 import org.springframework.stereotype.Service;
 import org.example.wecambackend.dto.responseDTO.DepartmentResponse;
@@ -165,5 +166,17 @@ public class CouncilMemberService {
 
     public List<CouncilCompositionResponse> getDepartmentCouncilMembers(Long councilId, Long departmentId) {
         return councilMemberRepository.findByCouncilIdAndDepartmentId(councilId,departmentId);
+    }
+
+    /**
+     * 학생회 구성원 검색 서비스
+     * 이름을 사용하여 학생회 구성원을 검색합니다.
+     * 
+     * @param name 검색할 이름
+     * @return 검색된 학생회 구성원 목록
+     */
+    @Transactional(readOnly = true)
+    public List<CouncilMemberSearchResponse> searchCouncilMembers(String name) {
+        return userRepository.searchCouncilMembers(name);
     }
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/service/admin/CouncilMemberService.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/service/admin/CouncilMemberService.java
@@ -170,13 +170,14 @@ public class CouncilMemberService {
 
     /**
      * 학생회 구성원 검색 서비스
-     * 이름을 사용하여 학생회 구성원을 검색합니다.
+     * 이름을 사용하여 현재 학생회의 구성원을 검색합니다.
      * 
      * @param name 검색할 이름
      * @return 검색된 학생회 구성원 목록
      */
     @Transactional(readOnly = true)
     public List<CouncilMemberSearchResponse> searchCouncilMembers(String name) {
-        return userRepository.searchCouncilMembers(name);
+        Long councilId = CouncilContextHolder.getCouncilId();
+        return userRepository.searchCouncilMembers(name, councilId);
     }
 }

--- a/wecam-backend/src/main/java/org/example/wecambackend/service/admin/StudentService.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/service/admin/StudentService.java
@@ -7,6 +7,8 @@ import org.example.wecambackend.common.exceptions.BaseException;
 import org.example.wecambackend.common.response.BaseResponseStatus;
 import org.example.wecambackend.dto.projection.OrganizationNameLevelDto;
 import org.example.wecambackend.dto.responseDTO.UserSummaryResponse;
+import org.example.wecambackend.dto.responseDTO.StudentSearchResponse;
+import org.example.wecambackend.dto.requestDTO.StudentSearchRequest;
 import org.example.wecambackend.repos.CouncilRepository;
 import org.example.wecambackend.repos.UserInformationRepository;
 import org.example.wecambackend.repos.UserRepository;
@@ -25,6 +27,8 @@ public class StudentService {
     private final UserRepository userRepository;
     private final UserInformationRepository userInformationRepository;
     private final EntityFinderService entityFinderService;
+    private final CouncilRepository councilRepository;
+
 
     /**
      * 일반 학생을 제명합니다.
@@ -101,6 +105,19 @@ public class StudentService {
                 .collect(Collectors.toList());
     }
 
-
-    private final CouncilRepository councilRepository;
+    /**
+     * 일반 학생 검색 서비스
+     * 이름, 입학년도, 학년 필터를 사용하여 학생을 검색합니다.
+     * 
+     * @param request 검색 조건
+     * @return 검색된 학생 목록
+     */
+    @Transactional(readOnly = true)
+    public List<StudentSearchResponse> searchStudents(StudentSearchRequest request) {
+        return userRepository.searchStudents(
+                request.getName(),
+                request.getYear(),
+                request.getGrade()
+        );
+    }
 }


### PR DESCRIPTION
## 🔀 Pull Request 제목
[구성원 검색 API] 학생회 구성원 및 일반 학생 검색

## ✅ 작업 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

학생회 관리자가 구성원을 효율적으로 검색할 수 있도록 QueryDSL 기반의 검색 API를 구현했습니다. 학생회 구성원과 일반 학생을 분리하여 각각에 최적화된 검색 기능을 제공하며, 필터링을 통해 다양한 검색 조건(학년, 학번)을 지원합니다.

- 작업 내용 : 구성원 관리 페이지에서 학생회 구성원, 일반 학생 검색 API 따로 구현 
- 작업 목적: 학생회 관리자의 구성원 검색 편의성 향상
- resolves: #42 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔧 주요 변경 사항


구분 | 변경 내용
-- | --
QueryDSL 설정 | domain-common 모듈에 QueryDSL 플러그인 및 의존성 추가, Q클래스 자동 생성
DTO 생성 | CouncilMemberSearchRequest, StudentSearchRequest, CouncilMemberSearchResponse, StudentSearchResponse 생성
Repository 구현 | UserCustomRepository, CouncilMemberCustomRepository 및 구현체 생성
Service 구현 | StudentService.searchStudents(), CouncilMemberService.searchCouncilMembers() 추가
API 엔드포인트 | GET /admin/council/{councilName}/student/search, GET /admin/council/{councilName}/member/search 추가
보안 처리 | @IsCouncil 어노테이션으로 학생회 구성원만 접근 가능
데이터 격리 | 현재 학생회 ID로 필터링하여 데이터 격리 보장
특별 로직 | 2019년 입학년도 선택 시 이전 연도까지 포함, 나머지는 정확히 일치
예외 처리 | academicStatus null 시 "정보 없음" 반환
문서화 | Swagger @Operation, @Parameter 어노테이션으로 API 문서화


## 🧪 테스트 내용

- [x] 학생회 구성원 검색 API 정상 동작 확인
- [x] 일반 학생 검색 API 정상 동작 확인
- [x] 다중 필터 조합 동작 확인


## 🧾API 사용 예시 (Swagger 문서화 연동)

**학생회 구성원 검색**
```http
GET /admin/council/컴퓨터공학부/member/search?name=김철수
```

**일반 학생 검색**
```http
# 모든 조건으로 검색
GET /admin/council/컴퓨터공학부/student/search?name=김철수

# 2025학번만 검색
GET /admin/council/컴퓨터공학부/student/search?name=김철수&year=2025

# 1학년만 검색
GET /admin/council/컴퓨터공학부/student/search?name=김철수&grade=1

# 2025학번 1학년만 검색
GET /admin/council/컴퓨터공학부/student/search?name=김철수&year=2025&grade=1

# 2019년 이전 입학한 학생 검색 (특별 처리)
GET /admin/council/컴퓨터공학부/student/search?name=김철수&year=2019
```

## 응답 예시
```json
{
  "success": true,
  "data": [
    {
      "userPkId": 1,
      "councilMemberPkId": 10,
      "name": "김철수",
      "studentNumber": "2025",
      "organizationName": "컴퓨터공학부",
      "departmentName": "기획부",
      "position": "부장",
      "profileImagePath": "/profile/image1.jpg"
    }
  ]
}
```