### PR TITLE
feat: 회의록 생성 API 추가

### DIFF
--- a/domain-common/src/main/java/org/example/model/category/Category.java
+++ b/domain-common/src/main/java/org/example/model/category/Category.java
@@ -4,11 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.model.common.BaseEntity;
 import org.example.model.council.Council;
-import org.example.model.todo.Todo;
-import org.example.model.user.User;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.example.model.council.CouncilMember;
 
 /**
  * 학생회별 카테고리를 나타내는 엔티티.
@@ -37,10 +33,10 @@ public class Category extends BaseEntity {
     @Column(name = "name", length = 50, nullable = false)
     private String name;
 
-    // 카테고리 생성자
+    // 카테고리 생성자 (학생회 구성원)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "created_user_id", nullable = false)
-    private User createdUser;
+    @JoinColumn(name = "created_member_id", nullable = false)
+    private CouncilMember createdMember;
 
     // 카테고리명 업데이트 메서드
     public void updateName(String name) {

--- a/domain-common/src/main/java/org/example/model/meeting/Meeting.java
+++ b/domain-common/src/main/java/org/example/model/meeting/Meeting.java
@@ -51,7 +51,7 @@ public class Meeting extends BaseEntity {
     @JoinColumn(name = "council_id", nullable = false)
     private Council council;
 
-    // 사용된 템플릿
+    // 만든 템플릿
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "template_id")
     private MeetingTemplate template;

--- a/wecam-backend/src/main/java/org/example/wecambackend/common/response/BaseResponseStatus.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/common/response/BaseResponseStatus.java
@@ -69,6 +69,9 @@ public enum BaseResponseStatus {
     ORGANIZATION_NOT_FOUND(false,  HttpStatus.NOT_FOUND.value(), "해당 조직을 찾을 수 없습니다."),
     SCHOOL_NOT_FOUND(false,  HttpStatus.NOT_FOUND.value(), "해당 학교를 찾을 수 없습니다."),
     USER_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "해당 유저를 찾을 수 없습니다."),
+    COUNCIL_MEMBER_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "해당 구성원을 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "해당 카테고리가 존재하지 않습니다."),
+    MEETING_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "해당 회의가 존재하지 않습니다."),
     INVITE_CODE_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "해당 초대코드가 존재하지 않습니다."),
     PHONE_INFO_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "전화번호 정보가 없습니다."),
     //로그인 시 이메일 정보 일치하지 않을 떄

--- a/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/MeetingController.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/controller/admin/MeetingController.java
@@ -1,0 +1,71 @@
+package org.example.wecambackend.controller.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.wecambackend.common.response.BaseResponse;
+import org.example.wecambackend.config.security.UserDetailsImpl;
+import org.example.wecambackend.config.security.annotation.IsCouncil;
+import org.example.wecambackend.dto.request.meeting.MeetingCreateRequest;
+import org.example.wecambackend.dto.response.meeting.MeetingResponse;
+import org.example.wecambackend.service.admin.meeting.MeetingService;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/council/{councilName}/meeting")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "MeetingController", description = "회의록 컨트롤러")
+public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    @IsCouncil
+    @PostMapping(value = "/create", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "회의록 생성",
+            description = "새로운 회의록을 생성합니다.",
+            parameters = {
+                    @Parameter(name = "councilName", description = "학생회 이름", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "X-Council-Id", description = "현재 접속한 학생회 ID", in = ParameterIn.HEADER, required = true)
+            }
+    )
+    public BaseResponse<MeetingResponse> createMeetingJson(
+            @RequestBody MeetingCreateRequest requestDto,
+            @PathVariable("councilName") String councilName,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+            MeetingResponse response = meetingService.createMeeting(requestDto, userDetails.getId());
+            return new BaseResponse<>(response);
+    }
+
+    @IsCouncil
+    @PostMapping(value = "/{meetingId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "회의록 첨부파일 업로드",
+            description = "기존 회의록에 첨부파일을 업로드합니다.",
+            parameters = {
+                    @Parameter(name = "councilName", description = "학생회 이름", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "회의록 ID", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "X-Council-Id", description = "현재 접속한 학생회 ID", in = ParameterIn.HEADER, required = true)
+            }
+    )
+    public BaseResponse<MeetingResponse> uploadMeetingFiles(
+            @PathVariable("meetingId") Long meetingId,
+            @PathVariable("councilName") String councilName,
+            @RequestPart(value = "files", required = true) List<MultipartFile> files,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+            MeetingResponse response = meetingService.addFilesToMeeting(meetingId, files, userDetails.getId());
+            return new BaseResponse<>(response);
+    }
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/auto/LoginRequest.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/auto/LoginRequest.java
@@ -10,10 +10,10 @@ import lombok.Setter;
 @NoArgsConstructor
 public class LoginRequest {
 
-    @Schema(description = "이메일", example = "president@example.com", required = true)
+    @Schema(description = "이메일", example = "college@wecampus.kr", required = true)
     private String email;
 
-    @Schema(description = "비밀번호", example = "1234", required = true)
+    @Schema(description = "비밀번호", example = "college!01", required = true)
     private String password;
 }
 

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/request/meeting/MeetingCreateRequest.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/request/meeting/MeetingCreateRequest.java
@@ -1,0 +1,53 @@
+package org.example.wecambackend.dto.request.meeting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.example.model.enums.MeetingAttendanceStatus;
+import org.example.model.enums.MeetingRole;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "회의록 생성 요청 DTO")
+public class MeetingCreateRequest {
+
+    @Schema(description = "회의록 제목", example = "2025년 1학기 정기회의")
+    private String title;
+
+    @Schema(description = "회의 일시", example = "2025-08-11T14:00:00")
+    private LocalDateTime meetingDateTime;
+
+    @Schema(description = "회의 장소", example = "학생회관 2층 회의실")
+    private String location;
+
+    @Schema(description = "회의 내용 (마크다운)", example = "# 회의 안건\n1. 학생회 예산 현황\n2. 다음 달 행사 계획\n3. 기타 논의사항")
+    private String content;
+
+    @Schema(description = "카테고리 ID", example = "1")
+    private Long categoryId;
+
+    @Schema(description = "참석자 목록")
+    private List<MeetingAttendeeRequest> attendees;
+
+    // 첨부파일은 MultipartFile로 별도 처리
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "회의 참석자 요청 DTO")
+    public static class MeetingAttendeeRequest {
+        @Schema(description = "학생회 멤버 ID", example = "123")
+        private Long councilMemberId;
+        
+        @Schema(description = "참석 상태 (기본값: PRESENT)", example = "PRESENT")
+        private MeetingAttendanceStatus attendanceStatus;
+        
+        @Schema(description = "회의 내 역할 (기본값: ATTENDEE)", example = "ATTENDEE")
+        private MeetingRole role;
+    }
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/response/meeting/MeetingResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/response/meeting/MeetingResponse.java
@@ -1,0 +1,97 @@
+package org.example.wecambackend.dto.response.meeting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.example.model.enums.MeetingAttendanceStatus;
+import org.example.model.enums.MeetingRole;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "회의록 응답 DTO")
+public class MeetingResponse {
+
+    @Schema(description = "회의록 고유 번호", example = "1")
+    private Long id;
+
+    @Schema(description = "회의록 제목", example = "2024년 1학기 정기회의")
+    private String title;
+
+    @Schema(description = "회의 일시", example = "2024-03-15T14:00:00")
+    private LocalDateTime meetingDateTime;
+
+    @Schema(description = "회의 장소", example = "학생회관 2층 회의실")
+    private String location;
+
+    @Schema(description = "회의 내용", example = "# 회의 안건\n1. 학생회 예산 현황\n2. 다음 달 행사 계획\n3. 기타 논의사항")
+    private String content;
+
+    @Schema(description = "회의록 생성자 ID", example = "123")
+    private Long createdById;
+
+    @Schema(description = "회의록 생성자 이름", example = "김학생")
+    private String createdByName;
+
+    @Schema(description = "카테고리 ID", example = "1")
+    private Long categoryId;
+
+    @Schema(description = "카테고리명", example = "정기회의")
+    private String categoryName;
+
+    @Schema(description = "참석자 목록")
+    private List<MeetingAttendeeResponse> attendees;
+
+    @Schema(description = "첨부파일 목록")
+    private List<MeetingFileResponse> files;
+
+    @Schema(description = "생성일시", example = "2024-03-15T10:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2024-03-15T10:00:00")
+    private LocalDateTime updatedAt;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "회의 참석자 응답 DTO")
+    public static class MeetingAttendeeResponse {
+        @Schema(description = "참석자 고유 번호", example = "1")
+        private Long id;
+        
+        @Schema(description = "학생회 멤버 이름", example = "김학생")
+        private String memberName;
+        
+        @Schema(description = "참석 상태", example = "PRESENT")
+        private MeetingAttendanceStatus attendanceStatus;
+        
+        @Schema(description = "회의 내 역할", example = "ATTENDEE")
+        private MeetingRole role;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "회의 첨부파일 응답 DTO")
+    public static class MeetingFileResponse {
+        @Schema(description = "파일 고유 번호", example = "1")
+        private Long id;
+        
+        @Schema(description = "원본 파일명", example = "회의자료.pdf")
+        private String fileName;
+        
+        @Schema(description = "파일 접근용 URL", example = "/uploads/meetings/1/abc123_회의자료.pdf")
+        private String fileUrl;
+        
+        @Schema(description = "파일 크기 (bytes)", example = "1024000")
+        private Long fileSize;
+        
+        @Schema(description = "파일 타입", example = "application/pdf")
+        private String fileType;
+    }
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/category/CategoryAssignmentRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/category/CategoryAssignmentRepository.java
@@ -1,0 +1,32 @@
+package org.example.wecambackend.repos.category;
+
+import org.example.model.category.CategoryAssignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CategoryAssignmentRepository extends JpaRepository<CategoryAssignment, Long> {
+
+    /**
+     * 특정 엔티티 타입과 ID에 대한 카테고리 할당 조회
+     */
+    Optional<CategoryAssignment> findByEntityTypeAndEntityId(CategoryAssignment.EntityType entityType, Long entityId);
+
+    /**
+     * 특정 엔티티 타입과 ID에 대한 카테고리 할당 목록 조회
+     */
+    List<CategoryAssignment> findByEntityTypeAndEntityIdIn(CategoryAssignment.EntityType entityType, List<Long> entityIds);
+
+    /**
+     * 특정 카테고리에 할당된 엔티티들 조회
+     */
+    List<CategoryAssignment> findByEntityTypeAndCategoryId(CategoryAssignment.EntityType entityType, Long categoryId);
+
+    /**
+     * 특정 엔티티 타입의 모든 할당 조회
+     */
+    List<CategoryAssignment> findByEntityType(CategoryAssignment.EntityType entityType);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/category/CategoryRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/category/CategoryRepository.java
@@ -1,0 +1,34 @@
+package org.example.wecambackend.repos.category;
+
+import org.example.model.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    /**
+     * 특정 학생회에 속한 카테고리들을 조회
+     */
+    List<Category> findByCouncilIdOrderByNameAsc(Long councilId);
+
+    /**
+     * 특정 학생회에서 특정 이름의 카테고리를 조회
+     */
+    Optional<Category> findByCouncilIdAndName(Long councilId, String name);
+
+    /**
+     * 특정 학생회에서 특정 ID의 카테고리를 조회
+     */
+    Optional<Category> findByIdAndCouncilId(Long id, Long councilId);
+
+    /**
+     * 특정 학생회에서 카테고리명 중복 확인
+     */
+    boolean existsByCouncilIdAndName(Long councilId, String name);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/council/CouncilMemberRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/council/CouncilMemberRepository.java
@@ -30,6 +30,10 @@ public interface CouncilMemberRepository extends JpaRepository<CouncilMember,Lon
 
     List<CouncilMember> findByUserUserPkIdAndStatus(Long userPkId, BaseEntity.Status ACTIVE);
 
+    /**
+     * 특정 사용자가 특정 학생회에 속한 특정 상태의 멤버인지 확인
+     */
+    Optional<CouncilMember> findByUserUserPkIdAndCouncilIdAndStatus(Long userId, Long councilId, BaseEntity.Status status);
 
     /**
      * 특정 학생회(councilId)에 속한 활성화된(CouncilMember.isActive = true) 구성원 중에서

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/meeting/MeetingAttendeeRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/meeting/MeetingAttendeeRepository.java
@@ -1,0 +1,24 @@
+package org.example.wecambackend.repos.meeting;
+
+import org.example.model.meeting.MeetingAttendee;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MeetingAttendeeRepository extends JpaRepository<MeetingAttendee, Long> {
+
+    // 특정 회의록의 참석자 목록 조회
+    List<MeetingAttendee> findByMeetingIdOrderByCreatedAtAsc(Long meetingId);
+
+    // 특정 회의록의 참석자 개수 조회
+    long countByMeetingId(Long meetingId);
+
+    // 특정 회의록의 참석자 삭제
+    void deleteByMeetingId(Long meetingId);
+
+    // 특정 회의록과 학생회 멤버로 참석자 조회
+    Optional<MeetingAttendee> findByMeetingIdAndCouncilMemberId(Long meetingId, Long councilMemberId);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/meeting/MeetingFileRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/meeting/MeetingFileRepository.java
@@ -1,0 +1,20 @@
+package org.example.wecambackend.repos.meeting;
+
+import org.example.model.meeting.MeetingFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MeetingFileRepository extends JpaRepository<MeetingFile, Long> {
+
+    // 특정 회의록의 첨부파일 목록 조회
+    List<MeetingFile> findByMeetingIdOrderByCreatedAtAsc(Long meetingId);
+
+    // 특정 회의록의 첨부파일 개수 조회
+    long countByMeetingId(Long meetingId);
+
+    // 특정 회의록의 첨부파일 삭제
+    void deleteByMeetingId(Long meetingId);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/meeting/MeetingRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/meeting/MeetingRepository.java
@@ -1,0 +1,33 @@
+package org.example.wecambackend.repos.meeting;
+
+import org.example.model.meeting.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    // 특정 학생회의 회의록 목록 조회
+    @Query("SELECT m FROM Meeting m " +
+           "WHERE m.council.id = :councilId " +
+           "ORDER BY m.meetingDateTime DESC")
+    List<Meeting> findAllByCouncilIdOrderByMeetingDateTimeDesc(@Param("councilId") Long councilId);
+
+    // 특정 학생회의 회의록 개수 조회
+    long countByCouncilId(Long councilId);
+
+    // 회의록 ID와 학생회 ID로 조회 (권한 확인용)
+    Optional<Meeting> findByIdAndCouncilId(Long id, Long councilId);
+
+    // 특정 사용자가 생성한 회의록 목록 조회
+    @Query("SELECT m FROM Meeting m " +
+           "JOIN m.createdBy cm " +
+           "WHERE cm.user.id = :userId " +
+           "ORDER BY m.createdAt DESC")
+    List<Meeting> findAllByCreatedByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/service/admin/meeting/MeetingService.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/service/admin/meeting/MeetingService.java
@@ -1,0 +1,295 @@
+package org.example.wecambackend.service.admin.meeting;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.model.common.BaseEntity;
+import org.example.model.council.Council;
+import org.example.model.council.CouncilMember;
+import org.example.model.meeting.Meeting;
+import org.example.model.meeting.MeetingAttendee;
+import org.example.model.meeting.MeetingFile;
+import org.example.model.enums.MeetingAttendanceStatus;
+import org.example.model.enums.MeetingRole;
+import org.example.model.user.User;
+import org.example.wecambackend.common.exceptions.BaseException;
+import org.example.wecambackend.common.response.BaseResponseStatus;
+import org.example.wecambackend.dto.request.meeting.MeetingCreateRequest;
+import org.example.wecambackend.dto.response.meeting.MeetingResponse;
+import org.example.wecambackend.repos.council.CouncilMemberRepository;
+import org.example.wecambackend.repos.council.CouncilRepository;
+import org.example.wecambackend.repos.meeting.MeetingAttendeeRepository;
+import org.example.wecambackend.repos.meeting.MeetingFileRepository;
+import org.example.wecambackend.repos.meeting.MeetingRepository;
+import org.example.wecambackend.repos.user.UserRepository;
+import org.example.wecambackend.repos.category.CategoryRepository;
+import org.example.wecambackend.repos.category.CategoryAssignmentRepository;
+import org.example.model.category.Category;
+import org.example.model.category.CategoryAssignment;
+import org.example.wecambackend.service.client.common.filesave.FileStorageService;
+import org.example.wecambackend.service.client.common.filesave.FilePath;
+import org.example.wecambackend.util.FileValidationUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MeetingService {
+
+    private final MeetingRepository meetingRepository;
+    private final MeetingFileRepository meetingFileRepository;
+    private final MeetingAttendeeRepository meetingAttendeeRepository;
+    private final CouncilMemberRepository councilMemberRepository;
+    private final CouncilRepository councilRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final CategoryAssignmentRepository categoryAssignmentRepository;
+    private final FileStorageService fileStorageService;
+
+    /**
+     * 회의록 생성
+     */
+    @Transactional
+    public MeetingResponse createMeeting(MeetingCreateRequest request, Long userId) {
+        // CouncilContextHolder에서 현재 학생회 ID 가져오기
+        Long councilId = org.example.wecambackend.common.context.CouncilContextHolder.getCouncilId();
+
+        // 1. 사용자 및 학생회 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+
+        Council council = councilRepository.findById(councilId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.COUNCIL_NOT_FOUND));
+
+        // 2. 사용자가 해당 학생회에 소속되어 있는지 확인
+        CouncilMember councilMember = councilMemberRepository
+                .findByUserUserPkIdAndCouncilIdAndStatus(userId, councilId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.COUNCIL_MISMATCH));
+
+        // 3. 회의록 엔티티 생성
+        Meeting meeting = Meeting.builder()
+                .title(request.getTitle())
+                .meetingDateTime(request.getMeetingDateTime())
+                .location(request.getLocation())
+                .content(request.getContent())
+                .council(council)
+                .createdBy(councilMember)
+                .build();
+
+        Meeting savedMeeting = meetingRepository.save(meeting);
+
+        // 4. 참석자 정보 저장
+        if (request.getAttendees() != null && !request.getAttendees().isEmpty()) {
+            saveMeetingAttendees(request.getAttendees(), savedMeeting);
+        }
+
+        // 5. 카테고리 할당
+        if (request.getCategoryId() != null) {
+            saveCategoryAssignment(request.getCategoryId(), savedMeeting.getId(), councilId);
+        }
+
+        return convertToResponse(savedMeeting);
+    }
+
+    /**
+     * 회의록에 파일 추가 업로드
+     */
+    @Transactional
+    public MeetingResponse addFilesToMeeting(Long meetingId, List<MultipartFile> files, Long userId) {
+        Long councilId = org.example.wecambackend.common.context.CouncilContextHolder.getCouncilId();
+
+        // 사용자 검증 및 권한 확인
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+
+        councilMemberRepository
+                .findByUserUserPkIdAndCouncilIdAndStatus(userId, councilId, BaseEntity.Status.ACTIVE)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.COUNCIL_MISMATCH));
+
+        // 회의록 조회 및 학생회 일치 확인
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MEETING_NOT_FOUND));
+        if (!meeting.getCouncil().getId().equals(councilId)) {
+            throw new BaseException(BaseResponseStatus.COUNCIL_MISMATCH);
+        }
+
+        // 작성자만 업로드 가능 확인
+        Long creatorUserId = meeting.getCreatedBy().getUser().getUserPkId();
+        if (!creatorUserId.equals(userId)) {
+            throw new BaseException(BaseResponseStatus.ONLY_AUTHOR_CAN_MODIFY);
+        }
+
+        // 파일 검증 및 저장
+        if (files != null && !files.isEmpty()) {
+            FileValidationUtil.validateAllFiles(files);
+            saveMeetingFiles(files, meeting, councilId);
+        } else {
+            throw new BaseException(BaseResponseStatus.INVALID_FILE_INPUT);
+        }
+
+        return convertToResponse(meeting);
+    }
+
+    /**
+     * 참석자 정보 저장
+     * TODO 구성원 별로 참석, 불참 또는 지각처리 해서 기록하게 할 수도 있음.
+     * TODO 참석자 별 역할 (참석자, 진행자, 기록자)도 기록 가능
+     * 지금은 일단 참석 정보만 저장하고, 역할도 다 참석자로 처리하는 중
+     */
+    private void saveMeetingAttendees(List<MeetingCreateRequest.MeetingAttendeeRequest> attendeeRequests, 
+                                    Meeting meeting) {
+        List<MeetingAttendee> attendees = new ArrayList<>();
+        
+        for (MeetingCreateRequest.MeetingAttendeeRequest request : attendeeRequests) {
+            CouncilMember member = councilMemberRepository.findById(request.getCouncilMemberId())
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.COUNCIL_MEMBER_NOT_FOUND));
+
+            MeetingAttendanceStatus status = MeetingAttendanceStatus.PRESENT;
+            if (request.getAttendanceStatus() != null) {
+                status = request.getAttendanceStatus();
+            }
+
+            MeetingRole role = MeetingRole.ATTENDEE;
+            if (request.getRole() != null) {
+                role = request.getRole();
+            }
+
+            MeetingAttendee attendee = MeetingAttendee.builder()
+                    .meeting(meeting)
+                    .councilMember(member)
+                    .attendanceStatus(status)
+                    .role(role)
+                    .build();
+
+            attendees.add(attendee);
+        }
+
+        meetingAttendeeRepository.saveAll(attendees);
+    }
+
+    /**
+     * 첨부파일 저장
+     */
+    private void saveMeetingFiles(List<MultipartFile> files, Meeting meeting, Long councilId) {
+        List<MeetingFile> meetingFiles = new ArrayList<>();
+        
+        for (MultipartFile file : files) {
+            if (file != null && !file.isEmpty()) {
+                MeetingFile meetingFile = uploadAndSaveFile(file, meeting, councilId);
+                meetingFiles.add(meetingFile);
+            }
+        }
+
+        if (!meetingFiles.isEmpty()) {
+            meetingFileRepository.saveAll(meetingFiles);
+        }
+    }
+
+    /**
+     * 파일 업로드 및 MeetingFile 엔티티 저장
+     */
+    private MeetingFile uploadAndSaveFile(MultipartFile file, Meeting meeting, Long councilId) {
+        try {
+            // UUID 생성
+            UUID fileUuid = UUID.randomUUID();
+            
+            // FileStorageService를 사용하여 파일 저장 (councilId 포함)
+            Map<String, String> fileInfo = fileStorageService.save(file, fileUuid, FilePath.MEETINGS, councilId);
+            
+            // MeetingFile 엔티티 생성
+            return MeetingFile.builder()
+                    .meeting(meeting)
+                    .fileName(file.getOriginalFilename())
+                    .filePath(fileInfo.get("filePath"))
+                    .fileUrl(fileInfo.get("fileUrl"))
+                    .fileSize(file.getSize())
+                    .fileType(file.getContentType())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("파일 업로드 실패", e);
+            throw new BaseException(BaseResponseStatus.FILE_SAVE_FAILED);
+        }
+    }
+
+    /**
+     * 카테고리 할당 저장
+     */
+    private void saveCategoryAssignment(Long categoryId, Long meetingId, Long councilId) {
+        // 카테고리가 해당 학생회에 속하는지 확인
+        Category category = categoryRepository.findByIdAndCouncilId(categoryId, councilId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.CATEGORY_NOT_FOUND));
+
+        // 카테고리 할당 생성
+        CategoryAssignment categoryAssignment = CategoryAssignment.create(
+                category, 
+                CategoryAssignment.EntityType.MEETING, 
+                meetingId
+        );
+
+        categoryAssignmentRepository.save(categoryAssignment);
+    }
+
+    /**
+     * Meeting 엔티티를 Response DTO로 변환
+     */
+    private MeetingResponse convertToResponse(Meeting meeting) {
+        // 참석자 정보 조회
+        List<MeetingAttendee> attendees = meetingAttendeeRepository.findByMeetingIdOrderByCreatedAtAsc(meeting.getId());
+        List<MeetingResponse.MeetingAttendeeResponse> attendeeResponses = attendees.stream()
+                .map(attendee -> MeetingResponse.MeetingAttendeeResponse.builder()
+                        .id(attendee.getId())
+                        .memberName(attendee.getCouncilMember().getUser().getName())
+                        .attendanceStatus(attendee.getAttendanceStatus())
+                        .role(attendee.getRole())
+                        .build())
+                .toList();
+
+        // 첨부파일 정보 조회
+        List<MeetingFile> files = meetingFileRepository.findByMeetingIdOrderByCreatedAtAsc(meeting.getId());
+        List<MeetingResponse.MeetingFileResponse> fileResponses = files.stream()
+                .map(file -> MeetingResponse.MeetingFileResponse.builder()
+                        .id(file.getId())
+                        .fileName(file.getFileName())
+                        .fileUrl(file.getFileUrl())
+                        .fileSize(file.getFileSize())
+                        .fileType(file.getFileType())
+                        .build())
+                .toList();
+
+        // 카테고리 정보 조회
+        String categoryName = null;
+        Long categoryId = null;
+        if (meeting.getId() != null) {
+            Optional<CategoryAssignment> categoryAssignment = categoryAssignmentRepository
+                    .findByEntityTypeAndEntityId(CategoryAssignment.EntityType.MEETING, meeting.getId());
+            if (categoryAssignment.isPresent()) {
+                categoryName = categoryAssignment.get().getCategory().getName();
+                categoryId = categoryAssignment.get().getCategory().getId();
+            }
+        }
+
+        return MeetingResponse.builder()
+                .id(meeting.getId())
+                .title(meeting.getTitle())
+                .meetingDateTime(meeting.getMeetingDateTime())
+                .location(meeting.getLocation())
+                .content(meeting.getContent())
+                .createdById(meeting.getCreatedBy().getId())
+                .createdByName(meeting.getCreatedBy().getUser().getName())
+                .categoryId(categoryId)
+                .categoryName(categoryName)
+                .attendees(attendeeResponses)
+                .files(fileResponses)
+                .createdAt(meeting.getCreatedAt())
+                .updatedAt(meeting.getUpdatedAt())
+                .build();
+    }
+}

--- a/wecam-backend/src/main/java/org/example/wecambackend/service/client/common/filesave/FilePath.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/service/client/common/filesave/FilePath.java
@@ -6,7 +6,8 @@ public enum FilePath {
     CURRENT_STUDENT("current-student"),
     PROFILE("profile"),
     PROFILE_THUMB("profile-thumb"),
-    PRESIDENT_AUTH("president-auth");
+    PRESIDENT_AUTH("president-auth"),
+    MEETINGS("meetings");
 
     private final String dirName;
 

--- a/wecam-backend/src/main/java/org/example/wecambackend/util/FileValidationUtil.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/util/FileValidationUtil.java
@@ -1,0 +1,81 @@
+package org.example.wecambackend.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.wecambackend.common.exceptions.BaseException;
+import org.example.wecambackend.common.response.BaseResponseStatus;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+public class FileValidationUtil {
+    // 허용된 파일 확장자
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("pdf", "jpg", "jpeg", "png");
+    // 최대 파일 크기 (10MB)
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+    // 최대 파일 개수
+    private static final int MAX_FILE_COUNT = 3;
+
+    /**
+     * 파일 개수 검증
+     */
+    public static void validateFileCount(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            return; // 파일이 없어도 OK
+        }
+        if (files.size() > MAX_FILE_COUNT) {
+            throw new BaseException(BaseResponseStatus.INVALID_INPUT, 
+                String.format("첨부파일은 최대 %d개까지 업로드 가능합니다. (현재: %d개)", MAX_FILE_COUNT, files.size()));
+        }
+    }
+
+    /**
+     * 개별 파일 검증
+     */
+    public static void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return; // 빈 파일은 OK
+        }
+        // 파일 크기 검증
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BaseException(BaseResponseStatus.INVALID_INPUT,
+                String.format("파일 크기는 최대 %dMB까지 가능합니다. (현재: %.2fMB)",
+                    MAX_FILE_SIZE / (1024 * 1024),
+                    file.getSize() / (1024.0 * 1024.0)));
+        }
+        // 파일 확장자 검증
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.isEmpty()) {
+            throw new BaseException(BaseResponseStatus.INVALID_INPUT, "파일명이 없습니다.");
+        }
+        String extension = getFileExtension(originalFilename);
+        if (!ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+            throw new BaseException(BaseResponseStatus.INVALID_INPUT,
+                String.format("허용되지 않는 파일 형식입니다. 허용된 형식: %s", String.join(", ", ALLOWED_EXTENSIONS)));
+        }
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private static String getFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            return "";
+        }
+        return filename.substring(lastDotIndex + 1);
+    }
+
+    /**
+     * 모든 파일 검증
+     */
+    public static void validateAllFiles(List<MultipartFile> files) {
+        validateFileCount(files);
+        if (files != null) {
+            for (MultipartFile file : files) {
+                validateFile(file);
+            }
+        }
+    }
+}

--- a/wecam-backend/src/main/resources/db/migration/V29__category_created_user_fk_to_council_member.sql
+++ b/wecam-backend/src/main/resources/db/migration/V29__category_created_user_fk_to_council_member.sql
@@ -1,0 +1,19 @@
+-- V29__category_created_user_fk_to_council_member.sql
+-- 목적: category.created_user_id 컬럼명을 created_member_id로 변경하고,
+--       FK 대상을 user(user_pk_id) → council_member(council_member_pk_id)로 변경
+
+-- 1) 기존 FK 제거 (V25에서 생성된 이름 기준)
+ALTER TABLE category
+  DROP FOREIGN KEY fk_category_user;
+
+-- 2) 컬럼명 변경: created_user_id -> created_member_id
+ALTER TABLE category
+  CHANGE COLUMN created_user_id created_member_id BIGINT NOT NULL;
+
+-- 3) 새 FK 추가: council_member를 참조하도록 변경
+ALTER TABLE category
+  ADD CONSTRAINT fk_category_created_member
+  FOREIGN KEY (created_member_id)
+  REFERENCES council_member(council_member_pk_id)
+  ON DELETE RESTRICT
+  ON UPDATE CASCADE;


### PR DESCRIPTION
## 🔀 Pull Request 제목
[회의록] 회의록 생성, 첨부파일 추가 API 추가, 카테고리 FK/컬럼 정합성 수정(V29)

## ✅ 작업 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
원래 한 번에 회의록 내용 등록 + 첨부파일 등록까지 하려고 했는데 잘 안 되어서(`application/octet-stream 에러 발생...`) API 2개로 나눴습니다. 회의록 첨부파일 저장 경로는 학생회 단위로 분리해 관리성과 보안성을 높이고자 했어용

또한 카테고리 생성자 FK가 원래 User랑 연결되어 있었는데, CouncilMember와 연관되는 게 맞는 것 같아서 테이블도 조금 수정했습니다!

<!---- Resolves: #55 -->
Resolves: #55 
- 목적: 안정적인 회의록 생성/업로드 흐름 확립, 도메인 정합성 강화, 파일 관리 체계화

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔧 주요 변경 사항


구분 | 변경 내용
-- | --
기능 추가 | 회의록 생성 API: `POST /admin/council/{councilName}/meeting/create` (application/json)
기능 추가 | 첨부파일 업로드 API: `POST /admin/council/{councilName}/meeting/{meetingId}/files` (multipart/form-data)
서비스 구현 | MeetingService.createMeeting(MeetingCreateRequest, Long userId)로 회의록 저장 (첨부파일 제외)
서비스 구현 | MeetingService.addFilesToMeeting(Long meetingId, List<MultipartFile> files, Long userId)로 첨부파일 저장
보안 처리 | 업로드 권한: 회의록 작성자만 가능(ONLY_AUTHOR_CAN_MODIFY)
파일 저장 | uploads/meetings/{council_id}/{UUID}_{원본파일명}로 저장
DB 마이그레이션 | V29__category_created_user_fk_to_council_member.sql: 컬럼명 created_user_id → created_member_id, FK를 council_member(council_member_pk_id)로 변경
엔티티 반영 | Category 엔티티 @JoinColumn(name = "created_member_id") 및 필드 createdMember로 정합화

## 🧪 테스트 내용

- [x] 작성자만 첨부파일 업로드 가능
- [x] 회의록 생성
- [x] 첨부파일 업로드 (개수 제한 동작 확인)

## 🧾 예외 응답 예시 (Swagger 문서화 연동)

```json
{
  "isSuccess": false,
  "code": 403,
  "message": "작성자만 수정할 수 있습니다."
}
```
