### PR TITLE
fix: 부서 배치 및 부서  상세 조회 API 스펙 변경

### DIFF
--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/projection/CompositionFlatRow.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/projection/CompositionFlatRow.java
@@ -3,7 +3,7 @@ package org.example.wecambackend.dto.projection;
 public interface CompositionFlatRow {
     Long   getDepartmentId();
     String getDepartmentName();
-    Long   getUserId();
+    Long   getCouncilMemberId();
     String getUserName();
     String getUserCouncilRole();
     Long   getDepartmentRoleId();

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/response/department/DepartmentResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/response/department/DepartmentResponse.java
@@ -19,10 +19,10 @@ import java.util.stream.Collectors;
 @Schema(description = "부서 정보 응답 DTO")
 public class DepartmentResponse {
     @Schema(description = "부서 ID", example = "1")
-    private Long id;
+    private Long departmentId;
 
     @Schema(description = "부서명", example = "기획부")
-    private String name;
+    private String departmentName;
 
     @Schema(description = "부서 내 역할 목록")
     private List<DepartmentRoleResponse> roles;

--- a/wecam-backend/src/main/java/org/example/wecambackend/dto/response/department/DepartmentRoleResponse.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/dto/response/department/DepartmentRoleResponse.java
@@ -15,10 +15,10 @@ import org.example.model.council.CouncilDepartmentRole;
 @Schema(description = "부서 역할 정보 응답 DTO")
 public class DepartmentRoleResponse {
     @Schema(description = "역할 ID", example = "1")
-    private Long id;
+    private Long roleId;
     
     @Schema(description = "역할명", example = "부장")
-    private String name;
+    private String roleName;
     
     @Schema(description = "역할 레벨 (숫자가 클수록 높은 권한)", example = "1")
     private Integer level;

--- a/wecam-backend/src/main/java/org/example/wecambackend/repos/council/CouncilMemberRepository.java
+++ b/wecam-backend/src/main/java/org/example/wecambackend/repos/council/CouncilMemberRepository.java
@@ -140,7 +140,7 @@ public interface CouncilMemberRepository extends JpaRepository<CouncilMember,Lon
     SELECT
       d.id                      AS departmentId,
       d.name                    AS departmentName,
-      u.user_pk_id              AS userId,
+      cm.council_member_pk_id   AS councilMemberId,
       u.name                    AS userName,
       cm.member_role            AS userCouncilRole,
       dr.id                     AS departmentRoleId,
@@ -163,7 +163,7 @@ public interface CouncilMemberRepository extends JpaRepository<CouncilMember,Lon
     SELECT
       NULL                      AS departmentId,
       NULL                      AS departmentName,
-      u.user_pk_id              AS userId,
+      cm.council_member_pk_id   AS councilMemberId,
       u.name                    AS userName,
       cm.member_role            AS userCouncilRole,
       cm.department_role_id     AS departmentRoleId,


### PR DESCRIPTION
- 부서 및 구성원 조회 시, userId 대신 councilMemberId 조회되도록 변경
- 부서명 및 직책 조회 API에서 필드명 좀 더 알아보기 쉽게 변경 (ex. id => departmentId)